### PR TITLE
fix path to 'required' file

### DIFF
--- a/lib/capybara-user_agent.rb
+++ b/lib/capybara-user_agent.rb
@@ -1,5 +1,5 @@
-require "capybara"
-require "user_agent"
+require 'capybara'
+require 'capybara/user_agent'
 
 module Capybara
   autoload :UserAgent, 'capybara/user_agent'


### PR DESCRIPTION
Fix for the following error I was receiving on ruby 1.9.3 ...

```
../gems/activesupport-3.2.14/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- user_agent (LoadError)
from ../gems/activesupport-3.2.14/lib/active_support/dependencies.rb:251:in `block in require'
from ../gems/activesupport-3.2.14/lib/active_support/dependencies.rb:236:in `load_dependency'
from ../gems/activesupport-3.2.14/lib/active_support/dependencies.rb:251:in `require'
from ../gems/capybara-user_agent-0.0.1/lib/capybara-user_agent.rb:2:in `<top (required)>'
... rest of stack trace ...
```
