### PR TITLE
Add license to gemspec

### DIFF
--- a/capybara-user_agent.gemspec
+++ b/capybara-user_agent.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{UserAgent DSL on Capybara}
   gem.summary       = %q{UserAgent DSL on Capybara}
   gem.homepage      = "https://github.com/mururu/capybara-user_agent"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/capybara-user_agent)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.
